### PR TITLE
Make Wikidata importing optional

### DIFF
--- a/language.sql
+++ b/language.sql
@@ -118,6 +118,7 @@ END;
 $$ STRICT
 LANGUAGE plpgsql IMMUTABLE;
 
+CREATE TABLE IF NOT EXISTS wd_names(id varchar(20), page varchar(200), labels hstore);
 
 CREATE OR REPLACE FUNCTION merge_wiki_names(tags hstore) RETURNS hstore AS $$
 DECLARE


### PR DESCRIPTION
If table "wd_names" is not in database, just create a new one 

1. In openmaptiles, "make import-sql" always fails at "merge_wiki_names" if
Wikidata is not imported
2. table information is at https://github.com/openmaptiles/import-wikidata/blob/1074ce6060aaf68ce99120d7fe9daec2d1fdecf5/wikidata/etl.py#L11-L15